### PR TITLE
Bumped dependencies and swapped bevy for bevy_ecs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,9 @@ opt-level = 1
 opt-level = 3
 
 [dependencies]
-aery = "0.4"
-bevy = {version = "0.11.3", default-features = false}
+aery = "0.5"
+bevy_ecs = { version = "0.12" }
 
 [dev-dependencies]
 rstest = "0.18.2"
+bevy = { version = "0.12" }

--- a/src/cells.rs
+++ b/src/cells.rs
@@ -1,5 +1,5 @@
 use aery::prelude::*;
-use bevy::prelude::*;
+use bevy_ecs::prelude::*;
 use std::collections::HashMap;
 use std::ops::Deref;
 

--- a/src/cells/cell_query.rs
+++ b/src/cells/cell_query.rs
@@ -1,16 +1,12 @@
-use std::ops::{Deref, DerefMut};
-
-use aery::prelude::*;
-use bevy::{
-    ecs::{
-        query::{ReadOnlyWorldQuery, WorldQuery},
-        system::SystemParam,
-    },
-    prelude::Query,
-};
-
 use super::{CellMap, CellMapLabel, Chunk, InChunk, InMap};
 use crate::cells::coords::*;
+use aery::prelude::*;
+use bevy_ecs::{
+    prelude::Query,
+    query::{ReadOnlyWorldQuery, WorldQuery},
+    system::SystemParam,
+};
+use std::ops::{Deref, DerefMut};
 
 /// Used to query individual cells from a cell map.
 /// This query also implicitly queries chunks and maps

--- a/src/cells/chunk_query.rs
+++ b/src/cells/chunk_query.rs
@@ -1,17 +1,12 @@
-use std::ops::{Deref, DerefMut};
-
-use aery::prelude::*;
-use bevy::{
-    ecs::{
-        prelude::With,
-        query::{ReadOnlyWorldQuery, WorldQuery},
-        system::SystemParam,
-    },
-    prelude::Query,
-};
-
 use super::{CellMap, CellMapLabel, Chunk, InMap};
 use crate::cells::coords::*;
+use aery::prelude::*;
+use bevy_ecs::{
+    prelude::*,
+    query::{ReadOnlyWorldQuery, WorldQuery},
+    system::SystemParam,
+};
+use std::ops::{Deref, DerefMut};
 
 /// Used to query chunks from a cell map.
 /// This query also implicitly queries maps

--- a/src/cells/commands.rs
+++ b/src/cells/commands.rs
@@ -9,9 +9,9 @@ use aery::{
     edges::CheckedDespawn,
     prelude::{Set, Unset},
 };
-use bevy::{
-    ecs::system::{Command, EntityCommands},
-    prelude::{Bundle, Commands, Entity, With, World},
+use bevy_ecs::{
+    prelude::*,
+    system::{Command, EntityCommands},
 };
 
 /// Applies commands to a specific cell map.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod cells;
 pub mod prelude {
     use std::ops::Deref;
 
-    use bevy::ecs::query::WorldQuery;
+    use bevy_ecs::query::WorldQuery;
 
     pub use crate::cells::cell_query::*;
     pub use crate::cells::commands::{CellCommandExt, CellCommands};


### PR DESCRIPTION
## Description

I've bumped this crate for the latest version of bevy (0.12) and swapped out its dependencies so that the crate itself only depends on `bevy_ecs` rather than the entirety of `bevy` (Excluding for tests)

## Changes
- Bevy bumped to 0.11.3->0.12
- Aery bumped to 0.4->0.5
- Swapped bevy dependency for bevy_ecs
- Added full bevy dependency for tests